### PR TITLE
Fix string display out of bound

### DIFF
--- a/osu.Game.Tournament/Localisation/Screens/CountdownStrings.cs
+++ b/osu.Game.Tournament/Localisation/Screens/CountdownStrings.cs
@@ -55,9 +55,9 @@ namespace osu.Game.Tournament.Localisation.Screens
         public static LocalisableString JustEndedPrompt(LocalisableString time) => new TranslatableString(getKey(@"just_ended_prompt"), @"Started {0}", time);
 
         /// <summary>
-        /// "Already started long ago..."
+        /// "Started long ago..."
         /// </summary>
-        public static LocalisableString LongEndedPrompt => new TranslatableString(getKey(@"long_ended_prompt"), @"Already started long ago...");
+        public static LocalisableString LongEndedPrompt => new TranslatableString(getKey(@"long_ended_prompt"), @"Started long ago...");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/37fbb401-35c7-400c-993f-2ed17fb0a8c2)

A quick fix involves simply shortening the strings. Empty time is relatively rare in osu! tournaments, so I left that unchanged. 