### PR TITLE
Change trigger conditions of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,14 @@
-on: [push, pull_request]
 name: Continuous Integration
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - "derived/new"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This PR would make CI's coverage limited to opened PRs only, which is enough for us.

## Why we should propose this change

- The original condition `push` somehow duplicates with the `pull_request` one, when new commits are pushed to the source branch of a PR, this would trigger two sets of CI simultaneously, which is generally not needed in our fork and can be considered as a waste of time.
- Most of our changes to the project code is commited by PRs, so running CIs on them is enough.
- Reduced CI failure notifications (yes, as few as we could).
