### PR TITLE
Make annotation action succeed when some tests are failed

### DIFF
--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -36,10 +36,16 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Annotate CI run with test results
-        uses: dorny/test-reporter@v1.8.0
+        uses: dorny/test-reporter@v2.0.0
         with:
           name: Results
           path: "*.trx"
           reporter: dotnet-trx
           list-suites: 'failed'
           list-tests: 'failed'
+
+          # Some tests failed, but you won.
+          fail-on-error: 'false'
+
+          # No test results is fine. Nothing to worry about.
+          fail-on-empty: 'false'


### PR DESCRIPTION
## Tasks

- The CI outputs are purely nightmares if they are too much and keep hitting your notification inbox.
- The annotation action shouldn't fail unless internal errors occur in itself. I'm pretty sure tests have nothing to do with this.
- Update the action to the latest version for new features and some bug fixes.
