### PR TITLE
Remove initial sizing in `EmptyBox` constructor

### DIFF
--- a/osu.Game.Tournament/Components/EmptyBox.cs
+++ b/osu.Game.Tournament/Components/EmptyBox.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Tournament.Components
@@ -20,6 +21,7 @@ namespace osu.Game.Tournament.Components
 
         public EmptyBox(int cornerRadius = 0)
         {
+            Size = Vector2.One;
             Masking = true;
             CornerRadius = cornerRadius;
 

--- a/osu.Game.Tournament/Components/EmptyBox.cs
+++ b/osu.Game.Tournament/Components/EmptyBox.cs
@@ -20,12 +20,8 @@ namespace osu.Game.Tournament.Components
 
         public EmptyBox(int cornerRadius = 0)
         {
-            Width = 250;
-            Height = 250;
-
             Masking = true;
             CornerRadius = cornerRadius;
-            // CornerExponent = 5;
 
             InternalChildren = new Drawable[]
             {


### PR DESCRIPTION
Fix the issue when using `RelativeSizeAxes` with size unset.
